### PR TITLE
Feature/retain mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,22 +171,42 @@ fun `my test`() {
 
 ### Mock the same request multiple times
 
-Each mock intercepts only 1 request, once a request is intercepted `NetMock` will remove the mock
-from the queue.
-This allows you to test what your code exactly does.
-If your code is making the same request multiple times (i.e polling) you would need to add a mock
-for each expected request:
+By default, each mock in `NetMock` intercepts only **one request**. After a request is intercepted,
+the mock is automatically removed from the queue. This behavior ensures precise control over your
+tests, allowing you to verify exactly how your code handles each request.
+
+However, if your code makes the same request multiple times (e.g., polling or retries), you can add
+multiple mocks for each expected request:
 
 ```kotlin
 @Test
 fun `my test`() {
-    netMock.addMock(request, response)
-    netMock.addMock(request, response)
-    netMock.addMock(request, response)
+    netMock.addMock(request, response) // Mock for the first request
+    netMock.addMock(request, response) // Mock for the second request
+    netMock.addMock(request, response) // Mock for the third request
 
-    //...
+    // ...
 }
 ```
+
+Alternatively, if the exact number of requests is not a concern in your test scenario, you can use
+the `retainMock = true` flag to create a persistent mock. This mock will remain in the queue and
+intercept all matching requests, even after the first interception:
+
+```kotlin
+@Test
+fun `my test`() {
+    netMock.addMock(request, response, retainMock = true) // Persistent mock
+    // or
+    // netMock.addMockWithCustomMatcher(requestMatcher, response, retainMock = true)
+
+    // ...
+}
+```
+This approach is particularly useful when:
+* Testing polling mechanisms or retry logic.
+* The number of requests is dynamic or unknown.
+* You want to simplify test setup by avoiding repetitive mock definitions.
 
 ## Verify intercepted requests
 

--- a/netmock-core/src/commonMain/kotlin/com/denisbrandi/netmock/NetMock.kt
+++ b/netmock-core/src/commonMain/kotlin/com/denisbrandi/netmock/NetMock.kt
@@ -13,73 +13,119 @@ interface NetMock {
     var defaultResponse: NetMockResponse?
 
     /**
-     * When a real request matches the provided [request], the provided [response] is returned.
-     * Once a real request is successfully intercepted the provided [request] and [response] are removed from the queue.
-     * If you want to make multiple identical requests and return the same response n times, just call this method n times with the same [request] and [response].
-     * @param [request] The request that has to match with the intercepted HTTP request
-     * @param [response] The response that will be mapped to HTTP response if the request matched an intercepted HTTP request.
+     * Mocks a response for a specific request. When an intercepted HTTP request matches the provided [request],
+     * the specified [response] is returned. After a successful interception, the [request] and [response] pair
+     * is removed from the queue unless [retainMock] is set to `true`.
+     *
+     * To mock multiple identical requests with the same response, call this method multiple times with the same
+     * [request] and [response]. Alternatively, set [retainMock] to `true` to keep the [request]/[response] pair
+     * in the queue indefinitely, ensuring all matching requests are mocked.
+     *
+     * By default, [retainMock] is set to `false`, meaning the mock is removed after the first match.
+     *
+     * @param request The request criteria to match against intercepted HTTP requests.
+     * @param response The response to return when the request criteria are met.
+     * @param retainMock If `true`, the mock remains in the queue after the first match, allowing it to be reused
+     * for subsequent requests. If `false`, the mock is removed after the first match. Defaults to `false`.
      */
-    fun addMock(request: NetMockRequest, response: NetMockResponse)
+    fun addMock(request: NetMockRequest, response: NetMockResponse, retainMock: Boolean = false)
 
     /**
-     * See [NetMock.addMock]
-     * Alternative way of adding request/response to the queue using builders.
+     * An alternative way to add a [request] and [response] pair to the queue using a builder pattern.
+     * This method functions similarly to [NetMock.addMock], but provides a more flexible and readable approach
+     * for defining responses using a builder.
      *
-     * @param [request] The request that has to match with the intercepted HTTP request
-     * @param [response] Function that allows you to create a [NetMockResponse] using a builder.
+     * When an intercepted HTTP request matches the provided [request], the response created by the [response]
+     * builder is returned. By default, the mock is removed after the first match unless [retainMock] is set to `true`.
+     *
+     * @param request The request criteria to match against intercepted HTTP requests.
+     * @param response A builder function that allows you to construct a [NetMockResponse] with custom properties.
+     * @param retainMock If `true`, the mock remains in the queue after the first match, allowing it to be reused
+     * for subsequent requests. If `false`, the mock is removed after the first match. Defaults to `false`.
+     *
+     * @see [NetMock.addMock] for the standard method of adding request/response pairs.
      */
     fun addMock(
         request: NetMockRequest,
-        response: NetMockResponseBuilder.() -> Unit
+        response: NetMockResponseBuilder.() -> Unit,
+        retainMock: Boolean = false
     ) {
         val responseBuilder = NetMockResponseBuilder()
         response(responseBuilder)
-        addMock(request, responseBuilder.build())
+        addMock(request, responseBuilder.build(), retainMock)
     }
 
     /**
-     * See [NetMock.addMock]
-     * Alternative way of adding request/response to the queue using builders.
+     * An alternative way to add a [request] and [response] pair to the queue using builder patterns for both.
+     * This method functions similarly to [NetMock.addMock], but provides a more flexible and readable approach
+     * for defining both requests and responses using builders.
      *
-     * @param [request] Function that allows you to create a [NetMockRequest] using a builder.
-     * @param [response] Function that allows you to create a [NetMockResponse] using a builder.
+     * The [request] builder allows you to construct a [NetMockRequest] with custom properties, while the [response]
+     * builder enables you to create a [NetMockResponse] tailored to your needs. This method is ideal for scenarios
+     * where you want to define complex request and response configurations in a clean and structured way.
+     *
+     * @param request A builder function that allows you to construct a [NetMockRequest] with custom properties.
+     * @param response A builder function that allows you to construct a [NetMockResponse] with custom properties.
+     * @param retainMock If `true`, the mock remains in the queue after the first match, allowing it to be reused
+     * for subsequent requests. If `false`, the mock is removed after the first match. Defaults to `false`.
+     *
+     * @see [NetMock.addMock] for the standard method of adding request/response pairs.
      */
     fun addMock(
         request: NetMockRequestBuilder.() -> Unit,
-        response: NetMockResponseBuilder.() -> Unit
+        response: NetMockResponseBuilder.() -> Unit,
+        retainMock: Boolean = false
     ) {
         val requestBuilder = NetMockRequestBuilder()
-        val responseBuilder = NetMockResponseBuilder()
         request(requestBuilder)
-        response(responseBuilder)
-        addMock(requestBuilder.build(), responseBuilder.build())
+        addMock(requestBuilder.build(), response, retainMock)
     }
 
     /**
-     * When a real request matches the provided [requestMatcher] criteria, the provided [response] is returned.
-     * Once a real request is successfully intercepted the provided [requestMatcher] and [response] are removed from the queue.
-     * If you want to make multiple identical requests and return the same response n times, just call this method n times with the same [requestMatcher] and [response].
-     * @param [requestMatcher] The custom match function that matches an intercepted HTTP request.
-     * @param [response] The response that will be mapped to HTTP response if the request matched an intercepted HTTP request.
+     * Mocks a response for requests that match a custom criteria defined by [requestMatcher]. When an intercepted
+     * HTTP request satisfies the [requestMatcher] condition, the specified [response] is returned. After a successful
+     * interception, the [requestMatcher] and [response] pair is removed from the queue unless [retainMock] is set to `true`.
+     *
+     * To mock multiple identical requests with the same response, call this method multiple times with the same
+     * [requestMatcher] and [response]. Alternatively, set [retainMock] to `true` to keep the [requestMatcher]/[response]
+     * pair in the queue indefinitely, ensuring all matching requests are mocked.
+     *
+     * By default, [retainMock] is set to `false`, meaning the mock is removed after the first match.
+     *
+     * @param requestMatcher A custom function that defines the criteria for matching intercepted HTTP requests.
+     * @param response The response to return when the request matches the [requestMatcher] criteria.
+     * @param retainMock If `true`, the mock remains in the queue after the first match, allowing it to be reused
+     * for subsequent requests. If `false`, the mock is removed after the first match. Defaults to `false`.
      */
     fun addMockWithCustomMatcher(
         requestMatcher: (interceptedRequest: NetMockRequest) -> Boolean,
-        response: NetMockResponse
+        response: NetMockResponse,
+        retainMock: Boolean = false
     )
 
     /**
-     * See [NetMock.addMockWithCustomMatcher]
-     * Alternative way of adding requestMatcher/response to the queue using builders.
+     * An alternative way to add a [requestMatcher] and [response] pair to the queue using a builder pattern.
+     * This method functions similarly to [NetMock.addMockWithCustomMatcher], but provides a more flexible and
+     * readable approach for defining responses using a builder.
      *
-     * @param [requestMatcher] The custom match function that matches an intercepted HTTP request.
-     * @param [response] Function that allows you to create a [NetMockResponse] using a builder.
+     * When an intercepted HTTP request matches the custom criteria defined by [requestMatcher], the response
+     * created by the [response] builder is returned. By default, the mock is removed after the first match unless
+     * [retainMock] is set to `true`.
+     *
+     * @param requestMatcher A custom function that defines the criteria for matching intercepted HTTP requests.
+     * @param response A builder function that allows you to construct a [NetMockResponse] with custom properties.
+     * @param retainMock If `true`, the mock remains in the queue after the first match, allowing it to be reused
+     * for subsequent requests. If `false`, the mock is removed after the first match. Defaults to `false`.
+     *
+     * @see [NetMock.addMockWithCustomMatcher] for the standard method of adding custom matchers.
      */
     fun addMockWithCustomMatcher(
         requestMatcher: (interceptedRequest: NetMockRequest) -> Boolean,
-        response: NetMockResponseBuilder.() -> Unit
+        response: NetMockResponseBuilder.() -> Unit,
+        retainMock: Boolean = false
     ) {
         val responseBuilder = NetMockResponseBuilder()
         response(responseBuilder)
-        addMockWithCustomMatcher(requestMatcher, responseBuilder.build())
+        addMockWithCustomMatcher(requestMatcher, responseBuilder.build(), retainMock)
     }
 }

--- a/netmock-core/src/commonMain/kotlin/com/denisbrandi/netmock/NetMockRequestResponse.kt
+++ b/netmock-core/src/commonMain/kotlin/com/denisbrandi/netmock/NetMockRequestResponse.kt
@@ -1,9 +1,18 @@
 package com.denisbrandi.netmock
 
 /**
- * Pair of a [NetMockRequest] and a [NetMockResponse]
+ * Represents a triple containing a [NetMockRequest], a [NetMockResponse], and a [retainMock] flag.
+ * This structure is used to define a request that needs to be intercepted, the corresponding response to be mocked,
+ * and whether the mock should persist after the first interception.
  *
- * @property request
- * @property response
+ * @property request The request that needs to be intercepted and matched against incoming HTTP requests.
+ * @property response The response to be returned when the [request] is successfully intercepted.
+ * @property retainMock If `true`, the triple will remain in the queue after the first interception, allowing it
+ * to be reused for subsequent matching requests. If `false`, the triple will be removed after the first match.
+ * Defaults to `false`.
  */
-data class NetMockRequestResponse(val request: NetMockRequest, val response: NetMockResponse)
+data class NetMockRequestResponse(
+    val request: NetMockRequest,
+    val response: NetMockResponse,
+    val retainMock: Boolean = false
+)

--- a/netmock-core/src/commonMain/kotlin/com/denisbrandi/netmock/interceptors/RequestInterceptor.kt
+++ b/netmock-core/src/commonMain/kotlin/com/denisbrandi/netmock/interceptors/RequestInterceptor.kt
@@ -7,11 +7,12 @@ interface RequestInterceptor {
     val allowedMocks: List<NetMockRequestResponse>
     var defaultResponse: NetMockResponse?
 
-    fun addMock(request: NetMockRequest, response: NetMockResponse)
+    fun addMock(request: NetMockRequest, response: NetMockResponse, retainMock: Boolean)
 
     fun addMockWithCustomMatcher(
         requestMatcher: (interceptedRequest: NetMockRequest) -> Boolean,
-        response: NetMockResponse
+        response: NetMockResponse,
+        retainMock: Boolean
     )
 
     fun intercept(interceptedRequest: InterceptedRequest): NetMockResponse

--- a/netmock-core/src/commonTest/kotlin/com/denisbrandi/netmock/NetMockTest.kt
+++ b/netmock-core/src/commonTest/kotlin/com/denisbrandi/netmock/NetMockTest.kt
@@ -21,11 +21,12 @@ class NetMockTest {
                 code = 200
                 mandatoryHeaders = mapOf("x" to "y")
                 body = "responseBody"
-            }
+            },
+            retainMock = true
         )
 
         assertEquals(
-            listOf(NetMockRequestResponse(EXPECTED_REQUEST, EXPECTED_RESPONSE)),
+            listOf(NetMockRequestResponse(EXPECTED_REQUEST, EXPECTED_RESPONSE, true)),
             sut.allowedMocks
         )
     }
@@ -95,11 +96,12 @@ class NetMockTest {
                 code = 200
                 mandatoryHeaders = mapOf("x" to "y")
                 body = "responseBody"
-            }
+            },
+            retainMock = true
         )
 
         assertEquals(
-            listOf(SpyNetMock.CustomInterceptor(CUSTOM_REQUEST_MATCHER, EXPECTED_RESPONSE)),
+            listOf(SpyNetMock.CustomInterceptor(CUSTOM_REQUEST_MATCHER, EXPECTED_RESPONSE, true)),
             sut.customInterceptors
         )
     }
@@ -153,20 +155,26 @@ class NetMockTest {
         override val allowedMocks = mutableListOf<NetMockRequestResponse>()
         override var defaultResponse: NetMockResponse? = null
         val customInterceptors = mutableListOf<CustomInterceptor>()
-        override fun addMock(request: NetMockRequest, response: NetMockResponse) {
-            allowedMocks.add(NetMockRequestResponse(request, response))
+        override fun addMock(
+            request: NetMockRequest,
+            response: NetMockResponse,
+            retainMock: Boolean
+        ) {
+            allowedMocks.add(NetMockRequestResponse(request, response, retainMock))
         }
 
         override fun addMockWithCustomMatcher(
             requestMatcher: (interceptedRequest: NetMockRequest) -> Boolean,
-            response: NetMockResponse
+            response: NetMockResponse,
+            retainMock: Boolean
         ) {
-            customInterceptors.add(CustomInterceptor(requestMatcher, response))
+            customInterceptors.add(CustomInterceptor(requestMatcher, response, retainMock))
         }
 
         data class CustomInterceptor(
             val requestMatcher: (interceptedRequest: NetMockRequest) -> Boolean,
-            val response: NetMockResponse
+            val response: NetMockResponse,
+            val retainMock: Boolean = false
         )
     }
 

--- a/netmock-engine/src/commonTest/kotlin/com/denisbrandi/netmock/engine/NetMockEngineTest.kt
+++ b/netmock-engine/src/commonTest/kotlin/com/denisbrandi/netmock/engine/NetMockEngineTest.kt
@@ -86,6 +86,51 @@ class NetMockEngineTest {
         assertTrue(netMock.allowedMocks.isEmpty())
     }
 
+    @JsName("mappedResponses_withRetainMock")
+    @Test
+    fun `EXPECT mapped responses WHEN retaining mocks`() = runTest {
+        netMock.addMock(EXPECTED_COMPLETE_REQUEST, EXPECTED_RESPONSE, retainMock = true)
+
+        val response1 = sut.request(getCompleteRequest(BASE_URL))
+        val response2 = sut.request(getCompleteRequest(BASE_URL))
+
+        assertEquals(
+            listOf(EXPECTED_COMPLETE_REQUEST, EXPECTED_COMPLETE_REQUEST),
+            netMock.interceptedRequests
+        )
+        assertValidResponse(EXPECTED_RESPONSE, response1)
+        assertValidResponse(EXPECTED_RESPONSE, response2)
+        assertEquals(
+            listOf(NetMockRequestResponse(EXPECTED_COMPLETE_REQUEST, EXPECTED_RESPONSE, true)),
+            netMock.allowedMocks
+        )
+    }
+
+    @JsName("mappedResponses_withRetainMockAndCustomMatcher")
+    @Test
+    fun `EXPECT mapped responses WHEN retaining mocks and using custom matcher`() = runTest {
+        netMock.addMockWithCustomMatcher(
+            requestMatcher = { it.requestUrl == EXPECTED_COMPLETE_REQUEST.requestUrl },
+            response = EXPECTED_RESPONSE,
+            retainMock = true
+        )
+
+        val response1 = sut.request(getCompleteRequest(BASE_URL))
+        val response2 = sut.request(getCompleteRequest(BASE_URL))
+
+        assertEquals(2, netMock.interceptedRequests.size)
+        assertInterceptedRequestWithCustomMatcher(
+            EXPECTED_COMPLETE_REQUEST,
+            netMock.interceptedRequests.first()
+        )
+        assertInterceptedRequestWithCustomMatcher(
+            EXPECTED_COMPLETE_REQUEST,
+            netMock.interceptedRequests[1]
+        )
+        assertValidResponse(EXPECTED_RESPONSE, response1)
+        assertValidResponse(EXPECTED_RESPONSE, response2)
+    }
+
     @JsName("mappedResponseAndDefaultResponse_noMoreMocks")
     @Test
     fun `EXPECT mapped responses and default response WHEN dispatcher runs out of mocks`() =

--- a/scripts/testLocal.sh
+++ b/scripts/testLocal.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+./gradlew clean
+./gradlew jvmTest
+./gradlew nativeTest
+./gradlew iOSX64Test
+./gradlew koverXmlReportCustom
+./scripts/testCoverageValidator.sh


### PR DESCRIPTION
### Added Support for Retaining Mocks

This PR introduces the ability to retain mocks by adding the `retainMock` flag to both `addMock` and `addMockWithCustomMatcher`. 

#### Key Changes:
- Developers can now specify whether a mock should persist after the first interception by setting the `retainMock` flag to `true`.
- This enables the creation of persistent mocks that can be reused for multiple matching requests, even when the exact number of requests is unknown or dynamic.

#### Use Case:
This feature is particularly useful in scenarios where the number of requests is unpredictable, such as:
- Testing retry mechanisms.
- Simulating repeated API calls without redefining the mock for each request.
- Handling dynamic or variable request patterns in tests.

By setting `retainMock` to `true`, developers can simplify test setups and reduce redundancy when dealing with repeated or unknown request counts.