### PR TITLE
Feature/fix non json body

### DIFF
--- a/netmock-engine/src/commonMain/kotlin/com/denisbrandi/netmock/engine/mappers/KtorRequestMapper.kt
+++ b/netmock-engine/src/commonMain/kotlin/com/denisbrandi/netmock/engine/mappers/KtorRequestMapper.kt
@@ -1,9 +1,9 @@
 package com.denisbrandi.netmock.engine.mappers
 
 import com.denisbrandi.netmock.interceptors.InterceptedRequest
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.http.content.*
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.Headers
+import io.ktor.http.content.OutgoingContent
 
 internal object KtorRequestMapper {
     fun mapRequest(request: HttpRequestData): InterceptedRequest {
@@ -24,8 +24,8 @@ internal object KtorRequestMapper {
     }
 
     private fun mapBody(outgoingContent: OutgoingContent): String {
-        return if (outgoingContent is TextContent) {
-            outgoingContent.text
+        return if (outgoingContent is OutgoingContent.ByteArrayContent) {
+            outgoingContent.bytes().decodeToString()
         } else {
             ""
         }

--- a/netmock-engine/src/commonTest/kotlin/com/denisbrandi/netmock/engine/FixtureRequestBody.kt
+++ b/netmock-engine/src/commonTest/kotlin/com/denisbrandi/netmock/engine/FixtureRequestBody.kt
@@ -5,3 +5,5 @@ const val REQUEST_BODY = """{
   "message": "some body message",
   "data": "some body text"
 }"""
+
+const val FORM_REQUEST_BODY = "form_key_1=form_value_1&form_key_2=form_value_2&form_key_2=form+value+3"

--- a/netmock-engine/src/commonTest/kotlin/com/denisbrandi/netmock/engine/mappers/KtorRequestMapperTest.kt
+++ b/netmock-engine/src/commonTest/kotlin/com/denisbrandi/netmock/engine/mappers/KtorRequestMapperTest.kt
@@ -1,0 +1,85 @@
+package com.denisbrandi.netmock.engine.mappers
+
+import com.denisbrandi.netmock.engine.*
+import com.denisbrandi.netmock.interceptors.InterceptedRequest
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.http.*
+import io.ktor.http.content.TextContent
+import kotlin.test.*
+
+class KtorRequestMapperTest {
+
+    private val sut = KtorRequestMapper
+
+    @Test
+    fun `EXPECT mapped request without body`() {
+        val requestData = HttpRequestBuilder().apply {
+            url(URL)
+            headers {
+                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            }
+            method = HttpMethod.Post
+        }.build()
+
+        val result = sut.mapRequest(requestData)
+
+        assertEquals(EXPECTED_POST_NO_BODY_REQUEST, result)
+    }
+
+    @Test
+    fun `EXPECT mapped POST json request`() {
+        val requestData = HttpRequestBuilder().apply {
+            url(URL)
+            headers {
+                append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            }
+            method = HttpMethod.Post
+            setBody(TextContent(REQUEST_BODY, ContentType.Application.Json))
+        }.build()
+
+        val result = sut.mapRequest(requestData)
+
+        assertEquals(EXPECTED_POST_JSON_REQUEST, result)
+    }
+
+    @Test
+    fun `EXPECT mapped POST form request`() {
+        val requestData = HttpRequestBuilder().apply {
+            url(URL)
+            headers {
+                append(HttpHeaders.ContentType, ContentType.Application.FormUrlEncoded.toString())
+            }
+            method = HttpMethod.Post
+            setBody(FORM_DATA)
+        }.build()
+
+        val result = sut.mapRequest(requestData)
+
+        assertEquals(EXPECTED_POST_FORM_REQUEST, result)
+    }
+
+    private companion object {
+        const val URL = "http://google.com/somePath?1=2&3=4"
+        val EXPECTED_POST_NO_BODY_REQUEST = InterceptedRequest(
+            requestUrl = URL,
+            method = "POST",
+            headers = mapOf(HttpHeaders.ContentType to ContentType.Application.Json.toString()),
+            body = ""
+        )
+        val EXPECTED_POST_JSON_REQUEST = EXPECTED_POST_NO_BODY_REQUEST.copy(
+            body = REQUEST_BODY
+        )
+
+        val FORM_DATA = FormDataContent(
+            parameters {
+                append("form_key_1", "form_value_1")
+                appendAll("form_key_2", listOf("form_value_2", "form value 3"))
+            }
+        )
+        val EXPECTED_POST_FORM_REQUEST = EXPECTED_POST_NO_BODY_REQUEST.copy(
+            headers = mapOf(HttpHeaders.ContentType to ContentType.Application.FormUrlEncoded.toString()),
+            body = FORM_REQUEST_BODY
+        )
+    }
+}

--- a/netmock-server/src/jvmMain/kotlin/com/denisbrandi/netmock/server/mappers/MockWebServerRequestMapper.kt
+++ b/netmock-server/src/jvmMain/kotlin/com/denisbrandi/netmock/server/mappers/MockWebServerRequestMapper.kt
@@ -9,7 +9,7 @@ internal object MockWebServerRequestMapper {
         val requestUrl =
             request.headers[INTERCEPTED_REQUEST_URL_HEADER] ?: request.requestUrl?.toString()
         // Body can be read only once
-        val recordedRequestBody = request.body.readUtf8()
+        val recordedRequestBody = request.body.clone().readUtf8()
         return InterceptedRequest(
             requestUrl = requestUrl.orEmpty(),
             method = request.method.orEmpty(),


### PR DESCRIPTION
* Fixed NetMock engine unable to match request bodies that are not plain text or json
* Cloned request body in netmock-server interceptor so that it can be read again